### PR TITLE
Change http to https to avoid mixed content error

### DIFF
--- a/src/components/recentCommits.jsx
+++ b/src/components/recentCommits.jsx
@@ -13,7 +13,7 @@ class recentCommits extends React.Component {
 
   componentWillMount() {
     const loopdata = [];
-    axios.get('http://api.github.com/orgs/icatproject/repos').then(reposResponse => {
+    axios.get('https://api.github.com/orgs/icatproject/repos').then(reposResponse => {
       const promises = [];
       for (let i = 0; i < reposResponse.data.length; i += 1) {
         const { name } = reposResponse.data[i];


### PR DESCRIPTION
We were getting a [Mixed Content](https://developer.mozilla.org/en-US/docs/Web/Security/Mixed_content) error due to the pages site being https but accessing the http github api