### PR TITLE
Change links to latest ICAT documentations

### DIFF
--- a/content/about/useful-links.md
+++ b/content/about/useful-links.md
@@ -12,7 +12,7 @@ Using these web pages
 
 [ICAT Server Rest Calls (4.8.0)](https://repo.icatproject.org/site/icat/server/4.8.0/miredot/index.html) – this shows the actual Rest interface offered by the server and is therefore language independent
 
-[Current (4.8.0) schema](https://repo.icatproject.org/site/icat/server/4.8.0/schema.html)
+[Current (4.10.0) schema](https://repo.icatproject.org/site/icat/server/4.10.0/schema.html)
 
 [icatgroup](http://groups.google.com/group/icatgroup) to which those interested in ICAT should subscribe.
 

--- a/content/about/useful-links.md
+++ b/content/about/useful-links.md
@@ -6,11 +6,11 @@ This page exists to give direct access to a number of useful pages:
 
 Using these web pages
 
-[Java ICAT Client SOAP API (4.8.0)](https://repo.icatproject.org/site/icat/client/4.8.0/manual_soap.html)
+[Java ICAT Client SOAP API (4.10.0)](https://repo.icatproject.org/site/icat/client/4.10.0/manual_soap.html)
 
-[Java ICAT Client Rest API (4.8.0)](https://repo.icatproject.org/site/icat/client/4.8.0/apidocs/index.html?org/icatproject/icat/client/package-summary.html)
+[Java ICAT Client Rest API (4.10.0)](https://repo.icatproject.org/site/icat/client/4.10.0/apidocs/index.html?org/icatproject/icat/client/package-summary.html)
 
-[ICAT Server Rest Calls (4.8.0)](https://repo.icatproject.org/site/icat/server/4.8.0/miredot/index.html) – this shows the actual Rest interface offered by the server and is therefore language independent
+[ICAT Server Rest Calls (4.9.1)](https://repo.icatproject.org/site/icat/server/4.9.1/miredot/index.html) – this shows the actual Rest interface offered by the server and is therefore language independent
 
 [Current (4.10.0) schema](https://repo.icatproject.org/site/icat/server/4.10.0/schema.html)
 

--- a/content/user-documentation/icat-schema.md
+++ b/content/user-documentation/icat-schema.md
@@ -72,7 +72,7 @@ space with agreed names.
 # The full schema
 
 The complete schema for each version of ICAT may be seen. For example
-[for 4.8.0](https://repo.icatproject.org/site/icat/server/4.8.0/schema.html).
+[for 4.10.0](https://repo.icatproject.org/site/icat/server/4.10.0/schema.html).
 This description of the schema is generated directly from the code. It
 omits five attributes which are carried by all entitites:
 


### PR DESCRIPTION
Closes #7 

Updates the URLs to point to the latest ICAT schema and API documentations. The link to the REST API points to the 4.9.1 api as, in the later versions, the link is broken