### PR TITLE
Remove all links to waffle.io

### DIFF
--- a/content/about/components-of-the-icat-project.md
+++ b/content/about/components-of-the-icat-project.md
@@ -6,11 +6,9 @@ Each components of the ICAT project has its own GitHub repository within
 an [icatproject organisation](https://github.com/icatproject) with the
 code, a small Wiki and the Issue (bug/ feature request) List for that
 component. If you simply want to install components then go to
-[Installation](/installation/ "Installation"). To
-get an overview of what is happening across the repositories take a look
-at [waffle.io](https://waffle.io/icatproject/icat.server)
+[Installation](/installation/ "Installation").
 
-![ICAT Components](/about/ICAT-Components.png "ICAT Components")
+![ICAT Components](../about/ICAT-Components.png "ICAT Components")
 
 - ICAT server and client : the metadata catalogue provides  a SOAP web
   service interface to the underlying database with an easy to use

--- a/content/collaboration/communication/monthly-meetings/2018-meetings/meeting-115-29th-march-2018.md
+++ b/content/collaboration/communication/monthly-meetings/2018-meetings/meeting-115-29th-march-2018.md
@@ -144,11 +144,10 @@ searchable data linked to ICAT.
 
 # Ticket Review (SP)
 
-- Looking at tickets on https://waffle.io/icatproject/icat.server
-  - a ‘Kanban’-style display of the open issues in the Icatproject
-    Github repositories. There are 4 columns: Backlog (containing
-    most of the issues), Ready (currently empty), In Progress and
-    Done.
+- Looking at the Waffle.io 'Kanban'-style issue tracker which displays
+  the open issues in the Icatproject Github repositories. There are 4
+  columns: Backlog (containing most of the issues), Ready (currently
+  empty), In Progress and Done.
 - Running out of time so only reviewing issues in ‘In Progress’
 - ‘In Progress’ should mean the owner expects to report on it at next
   meeting.

--- a/src/components/sidebar.jsx
+++ b/src/components/sidebar.jsx
@@ -132,20 +132,6 @@ export const Sidebar = () => (
             css={css`
               ${linkStyle}
             `}
-            href="https://waffle.io/icatproject/icat.server"
-          >
-            Waffle.io dashboard
-          </a>
-        </li>
-        <li
-          css={css`
-            ${liStyle}
-          `}
-        >
-          <a
-            css={css`
-              ${linkStyle}
-            `}
             href="https://github.com/icatproject"
           >
             Github for icatproject


### PR DESCRIPTION
Closes #8 

Removes all links to waffle.io and loads the `ICAT-Components.png` image properly.