### PR TITLE
Update current versions & remove topcat snapshot

### DIFF
--- a/content/releases/current-release.md
+++ b/content/releases/current-release.md
@@ -11,22 +11,22 @@ normally the highest number as listed below.  You can find release
 notes, installation instructions and the distribution in addition to
 user and developer documentation.
 
-- [authn.anon](https://repo.icatproject.org/site/authn/anon) -- 2.0.0
-- [authn.db](https://repo.icatproject.org/site/authn/db) -- 2.0.0
-- [authn.ldap](https://repo.icatproject.org/site/authn/ldap) -- 2.0.0
+- [authn.anon](https://repo.icatproject.org/site/authn/anon) -- 2.0.1
+- [authn.db](https://repo.icatproject.org/site/authn/db) -- 2.0.1
+- [authn.ldap](https://repo.icatproject.org/site/authn/ldap) -- 2.0.1
 - [authn.simple](https://repo.icatproject.org/site/authn/simple) --
-  2.0.0
+  2.0.1
 - [authn.oidc](https://repo.icatproject.org/site/authn/oidc) -- 1.0.0
 - [icat.server](https://repo.icatproject.org/site/icat/server) -- 4.11.1
 - [icat.client](https://repo.icatproject.org/site/icat/client) -- 4.11.1
-- [icat.lucene](https://repo.icatproject.org/site/icat/lucene) -- 1.1.0
+- [icat.lucene](https://repo.icatproject.org/site/icat/lucene) -- 1.1.2
 - [icat.oaipmh](https://repo.icatproject.org/site/icat/oaipmh) -- 1.1.1
 - [ids.server](https://repo.icatproject.org/site/ids/server) -- 1.12.0
 - [ids.client](https://repo.icatproject.org/site/ids/client) -- 1.3.0
 - [ids.plugin](https://repo.icatproject.org/site/ids/plugin) -- 1.5.0
 - [ids.storage_file](https://repo.icatproject.org/site/ids/storage_file) --
   1.4.3
-- [topcat](https://repo.icatproject.org/site/topcat) -- 2.4.8
+- [topcat](https://repo.icatproject.org/site/topcat) -- 2.4.9
 
 ## Issues with the current releases
 

--- a/content/releases/snapshot-releases.md
+++ b/content/releases/snapshot-releases.md
@@ -10,4 +10,4 @@ this is expected to be the last SNAPSHOT prior to release.
 
 | Component        | Snapshot | Distro                                                                                                                                                                                         | Final? |
 | ---------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| topcat      | 2.4.9    | [topcat-2.4.9-20220519.083152-2-distro.zip](https://repo.icatproject.org/repo/org/icatproject/topcat/2.4.9-SNAPSHOT/topcat-2.4.9-20220519.083152-2-distro.zip)               | yes    |
+| | | | |


### PR DESCRIPTION
Self explanatory. I was primarily meant to be updating the topcat version number, but I noticed some other components were out of date as well.