### PR TITLE
Update versions

### DIFF
--- a/content/about/useful-links.md
+++ b/content/about/useful-links.md
@@ -6,13 +6,13 @@ This page exists to give direct access to a number of useful pages:
 
 Using these web pages
 
-[Java ICAT Client SOAP API (4.10.0)](https://repo.icatproject.org/site/icat/client/4.10.0/manual_soap.html)
+[Java ICAT Client SOAP API (5.0.0)](https://repo.icatproject.org/site/icat/client/5.0.0/manual_soap.html)
 
-[Java ICAT Client Rest API (4.10.0)](https://repo.icatproject.org/site/icat/client/4.10.0/apidocs/index.html?org/icatproject/icat/client/package-summary.html)
+[Java ICAT Client Rest API (5.0.0)](https://repo.icatproject.org/site/icat/client/5.0.0/apidocs/index.html?org/icatproject/icat/client/package-summary.html)
 
-[ICAT Server Rest Calls (4.9.1)](https://repo.icatproject.org/site/icat/server/4.9.1/miredot/index.html) – this shows the actual Rest interface offered by the server and is therefore language independent
+[ICAT Server Rest Calls (5.0.0)](https://repo.icatproject.org/site/icat/server/5.0.0/miredot/index.html) – this shows the actual Rest interface offered by the server and is therefore language independent
 
-[Current (4.10.0) schema](https://repo.icatproject.org/site/icat/server/4.10.0/schema.html)
+[Current (5.0.0) schema](https://repo.icatproject.org/site/icat/server/5.0.0/schema.html)
 
 [icatgroup](http://groups.google.com/group/icatgroup) to which those interested in ICAT should subscribe.
 

--- a/content/releases/current-release.md
+++ b/content/releases/current-release.md
@@ -17,8 +17,8 @@ user and developer documentation.
 - [authn.simple](https://repo.icatproject.org/site/authn/simple) --
   2.0.1
 - [authn.oidc](https://repo.icatproject.org/site/authn/oidc) -- 1.0.0
-- [icat.server](https://repo.icatproject.org/site/icat/server) -- 4.11.1
-- [icat.client](https://repo.icatproject.org/site/icat/client) -- 4.11.1
+- [icat.server](https://repo.icatproject.org/site/icat/server) -- 5.0.0
+- [icat.client](https://repo.icatproject.org/site/icat/client) -- 5.0.0
 - [icat.lucene](https://repo.icatproject.org/site/icat/lucene) -- 1.1.2
 - [icat.oaipmh](https://repo.icatproject.org/site/icat/oaipmh) -- 1.1.1
 - [ids.server](https://repo.icatproject.org/site/ids/server) -- 1.12.0


### PR DESCRIPTION
Update the content at [ICAT Project](https://icatproject.org/) to reference current ICAT versions.