### PR TITLE
Fix recent commit list

### DIFF
--- a/src/components/recentCommits.jsx
+++ b/src/components/recentCommits.jsx
@@ -2,39 +2,108 @@ import React from 'react';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 
-function RecentCommits({ styles: { ulStyle, liStyle, linkStyle, headerStyle } }) {
-  const [githubData, setGithubData] = React.useState([]);
+/**
+ * Gets the most recent commit to the given repo if it exists, otherwise null
+ *
+ * @param repo a repository object from the github API
+ * @returns {Promise<Response>} an object representing the most recent commit
+ * in the repo if it exists, with the fields 'name', 'url', and 'date', otherwise
+ * null
+ */
+async function fetchRepoMostRecentCommit(repo) {
+  const commitUrl = repo.commits_url;
+  // Cut off '{/sha}' at the end of the commits url
+  const parts = commitUrl.split('{');
+  return fetch(parts[0])
+    .then(async (commitsResponse) => {
+      const commitsData = await commitsResponse.json();
 
+      if (commitsData.length === 0) return null;
+
+      const mostRecent = commitsData[0];
+      return {
+        name: repo.name,
+        url: mostRecent.html_url,
+        date: mostRecent.commit.author.date,
+      };
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.warn(`Error ${error}`);
+      return null;
+    });
+}
+
+/**
+ * Fetches the most recent commits for all the repos in the icatproject
+ * github organisation
+ *
+ * Note that this uses unauthenticated requests to the github API, which are
+ * strictly rate limited, and therefore should not be called often.
+ * @returns {Promise<*[]>}
+ */
+async function fetchRecentCommits() {
+  const commits = [];
+  await fetch('https://api.github.com/orgs/icatproject/repos?sort=updated')
+    .then(async (reposResponse) => {
+      const reposData = await reposResponse.json();
+      const promises = reposData.map((repo) =>
+        fetchRepoMostRecentCommit(repo)
+          .then((commit) => {
+            if (commit !== null) commits.push(commit);
+          })
+          .catch(() =>
+            // eslint-disable-next-line no-console
+            console.warn(`Failed to retrieve commit for ${repo}`)
+          )
+      );
+      await Promise.all(promises);
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.warn(`Error ${error}`);
+      return [];
+    });
+  return commits;
+}
+
+const hourInMillis = 60 * 60 * 1000;
+function isStillRecent(date) {
+  return new Date().valueOf() - date.valueOf() < hourInMillis;
+}
+/**
+ * Loads and displays links to the most recent commits in icatproject repos
+ */
+function RecentCommits({ styles: { ulStyle, liStyle, linkStyle, headerStyle } }) {
+  const [githubData, setGithubData] = React.useState(null);
+
+  /*
+  Unauthenticated requests to the github API are rate limited to 60 per hour.
+  To avoid this, we cache results in local storage and only refetch from github
+  at most once per hour.
+  */
   React.useEffect(() => {
-    const loopdata = [];
-    fetch('https://api.github.com/orgs/icatproject/repos')
-      .then((reposResponse) => {
-        const promises = [];
-        for (let i = 0; i < reposResponse.data.length; i += 1) {
-          const { name } = reposResponse.data[i];
-          const promise = fetch(`${reposResponse.data[i].url}/commits`)
-            .then((commitsResponse) => {
-              const object = {
-                name,
-                url: commitsResponse.data[0].html_url,
-                date: commitsResponse.data[0].commit.committer.date,
-              };
-              loopdata.push(object);
-            })
-            .catch((error) => {
-              // eslint-disable-next-line no-console
-              console.log(`Error ${error}`);
-            });
-          promises.push(promise);
-        }
-        Promise.all(promises).then(() => {
-          setGithubData(loopdata.sort((a, b) => new Date(b.date) - new Date(a.date)));
-        });
-      })
-      .catch((error) => {
-        // eslint-disable-next-line no-console
-        console.log(`Error ${error}`);
-      });
+    async function loadRecentCommits() {
+      const serializedLastFetchTime = localStorage.getItem('recentCommitsFetchTime');
+      const serializedRecents = localStorage.getItem('recentCommits');
+
+      const cacheIsValid =
+        serializedLastFetchTime !== null &&
+        serializedRecents !== null &&
+        isStillRecent(new Date(serializedLastFetchTime));
+
+      if (cacheIsValid) {
+        setGithubData(JSON.parse(serializedRecents));
+      } else {
+        const recents = await fetchRecentCommits();
+        recents.sort((a, b) => new Date(b.date) - new Date(a.date));
+        localStorage.setItem('recentCommits', JSON.stringify(recents));
+        localStorage.setItem('recentCommitsFetchTime', new Date());
+        setGithubData(recents);
+      }
+    }
+
+    loadRecentCommits();
   }, []);
 
   return (
@@ -52,8 +121,16 @@ function RecentCommits({ styles: { ulStyle, liStyle, linkStyle, headerStyle } })
             ${ulStyle}
           `}
         >
-          {githubData.length > 0 ? (
-            githubData.slice(0, 5).map((data) => (
+          {githubData === null ? (
+            <li
+              css={css`
+                ${liStyle}
+              `}
+            >
+              Loading...
+            </li>
+          ) : (
+            githubData.slice(0, 10).map((data) => (
               <li
                 css={css`
                   ${liStyle}
@@ -70,14 +147,6 @@ function RecentCommits({ styles: { ulStyle, liStyle, linkStyle, headerStyle } })
                 </a>
               </li>
             ))
-          ) : (
-            <li
-              css={css`
-                ${liStyle}
-              `}
-            >
-              Loading...
-            </li>
           )}
         </ul>
       </nav>


### PR DESCRIPTION
The recent commit list lives again (if it ever did before?):
![image](https://github.com/icatproject/icatproject.github.io/assets/8781899/27cc880f-bd5a-47e6-b5a6-eace1aebd2d3)

The list component had two major problems, which this  fixes:
 - Fields which didn't exist were being used on the objects which are returned from the github API, possibly because the API has changed.
 - Unauthenticated requests to the github API are rate limited to 60 per hour, so firing 21 requests on every page load hit that limit very quickly. This commit causes them to be cached in localStorage as a workaround

Additionally, we use the 'sort=updated' query parameter on the first call to the API to ensure we get the most recently updated repos, and show 10 repos instead of 5 because it felt quite short.

Probably a more 'ideal' way to fix this would be to set up a GH account for doing the fetching, and render the list server side with its API token, but that seems like it'd be pretty tricky to set up, and the simplicity of this solution seems better IMO.