### PR TITLE
Update to provide DOI landing pages for ICAT components.

### DIFF
--- a/content/releases/index.md
+++ b/content/releases/index.md
@@ -9,3 +9,24 @@ put into production.
 
 There is  a list of the latest [current releases](/releases/current-release/ "Current release") and one of
 available [snapshot releases](/releases/snapshot-releases/ "Snapshot releases").
+
+# Citation
+
+When referencing this software suit please use the following citation:
+
+Collaboration, T. I. C. A. T. (2014). The ICAT Project. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT
+
+# Packages
+
+- [Authn Anon](/releases/packages/authn-anon/authn-anon/)
+- [Authn DB](/releases/packages/authn-db/authn-db/)
+- [Authn LDAP](/releases/packages/authn-ldap/authn-ldap/)
+- [Authn Simple](/releases/packages/authn-simple/authn-simple/)
+- [ICAT Client](/releases/packages/icat-client/icat-client/)
+- [ICAT Server](/releases/packages/icat-server/icat-server/)
+- [IDS Client](/releases/packages/ids-client/ids-client/)
+- [IDS Plugin](/releases/packages/ids-plugin/ids-plugin/)
+- [IDS Server](/releases/packages/ids-server/ids-server/)
+- [IDS Storage File ](/releases/packages/ids-storage_file/ids-storage_file/)
+- [IJP Server](/releases/packages/ijp-server/ijp-server/)
+- [Topcat](/releases/packages/topcat/topcat/)

--- a/content/releases/packages/authn-anon/1-0-0.md
+++ b/content/releases/packages/authn-anon/1-0-0.md
@@ -1,0 +1,16 @@
+---
+title: Authn Anon 1.0.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/anon/).
+
+This release is for the [Authn Anon](/releases/packages/authn-anon/authn-anon/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.anon version 1.0.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.ANON/1.0.0
+
+# Software
+Authn Anon software version [1.0.0](https://repo.icatproject.org/site/authn/anon/1.0.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-anon/1-0-1.md
+++ b/content/releases/packages/authn-anon/1-0-1.md
@@ -1,0 +1,16 @@
+---
+title: Authn Anon 1.0.1
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/anon/).
+
+This release is for the [Authn Anon](/releases/packages/authn-anon/authn-anon/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.anon version 1.0.1. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.ANON/1.0.1
+
+# Software
+Authn Anon software version [1.0.1](https://repo.icatproject.org/site/authn/anon/1.0.1/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-anon/1-0-2.md
+++ b/content/releases/packages/authn-anon/1-0-2.md
@@ -1,0 +1,16 @@
+---
+title: Authn Anon 1.0.2
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/anon/).
+
+This release is for the [Authn Anon](/releases/packages/authn-anon/authn-anon/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: authn.anon version 1.0.2. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.ANON/1.0.2
+
+# Software
+Authn Anon software version [1.0.2](https://repo.icatproject.org/site/authn/anon/1.0.2/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-anon/authn-anon.md
+++ b/content/releases/packages/authn-anon/authn-anon.md
@@ -1,0 +1,22 @@
+---
+title: Authn Anon
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: authn.anon. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.ANON
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/authn/anon/)
+ 
+## Previous Releases
+
+ - [1.0.2](/releases/packages/authn-anon/1-0-2/)
+ - [1.0.1](/releases/packages/authn-anon/1-0-1/)
+ - [1.0.0](/releases/packages/authn-anon/1-0-0/)
+ 

--- a/content/releases/packages/authn-db/1-0-0.md
+++ b/content/releases/packages/authn-db/1-0-0.md
@@ -1,0 +1,16 @@
+---
+title: Authn DB 1.0.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/db/).
+
+This release is for the [Authn DB](/releases/packages/authn-db/authn-db/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.db version 1.0.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.DB/1.0.0
+
+# Software
+Authn DB software version [1.0.0](https://repo.icatproject.org/site/authn/db/1.0.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-db/1-1-0.md
+++ b/content/releases/packages/authn-db/1-1-0.md
@@ -1,0 +1,16 @@
+---
+title: Authn DB 1.1.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/db/).
+
+This release is for the [Authn DB](/releases/packages/authn-db/authn-db/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.db version 1.1.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.DB/1.1.0
+
+# Software
+Authn DB software version [1.1.0](https://repo.icatproject.org/site/authn/db/1.1.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-db/1-1-1.md
+++ b/content/releases/packages/authn-db/1-1-1.md
@@ -1,0 +1,16 @@
+---
+title: Authn DB 1.1.1
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/db/).
+
+This release is for the [Authn DB](/releases/packages/authn-db/authn-db/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.db version 1.1.1. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.DB/1.1.1
+
+# Software
+Authn DB software version [1.1.1](https://repo.icatproject.org/site/authn/db/1.1.1/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-db/1-1-2.md
+++ b/content/releases/packages/authn-db/1-1-2.md
@@ -1,0 +1,16 @@
+---
+title: Authn DB 1.1.2
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/db/).
+
+This release is for the [Authn DB](/releases/packages/authn-db/authn-db/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: authn.db version 1.1.2. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.DB/1.1.2
+
+# Software
+Authn DB software version [1.1.2](https://repo.icatproject.org/site/authn/db/1.1.2/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-db/authn-db.md
+++ b/content/releases/packages/authn-db/authn-db.md
@@ -1,0 +1,23 @@
+---
+title: Authn DB
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: authn.db. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.DB
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/authn/db/)
+ 
+## Previous Releases
+
+ - [1.1.2](/releases/packages/authn-db/1-1-2/)
+ - [1.1.1](/releases/packages/authn-db/1-1-1/)
+ - [1.1.0](/releases/packages/authn-db/1-1-0/)
+ - [1.0.0](/releases/packages/authn-db/1-0-0/)
+ 

--- a/content/releases/packages/authn-ldap/1-0-0.md
+++ b/content/releases/packages/authn-ldap/1-0-0.md
@@ -1,0 +1,16 @@
+---
+title: Authn LDAP 1.0.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/ldap/).
+
+This release is for the [Authn LDAP](/releases/packages/authn-ldap/authn-ldap/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.ldap version 1.0.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.LDAP/1.0.0
+
+# Software
+Authn LDAP software version [1.0.0](https://repo.icatproject.org/site/authn/ldap/1.0.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-ldap/1-1-0.md
+++ b/content/releases/packages/authn-ldap/1-1-0.md
@@ -1,0 +1,16 @@
+---
+title: Authn LDAP 1.1.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/ldap/).
+
+This release is for the [Authn LDAP](/releases/packages/authn-ldap/authn-ldap/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.ldap version 1.1.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.LDAP/1.1.0
+
+# Software
+Authn LDAP software version [1.1.0](https://repo.icatproject.org/site/authn/ldap/1.1.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-ldap/authn-ldap.md
+++ b/content/releases/packages/authn-ldap/authn-ldap.md
@@ -1,0 +1,21 @@
+---
+title: Authn LDAP
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: authn.ldap. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.LDAP
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/authn/ldap/)
+ 
+## Previous Releases
+
+ - [1.1.0](/releases/packages/authn-ldap/1-1-0/)
+ - [1.0.0](/releases/packages/authn-ldap/1-0-0/)
+ 

--- a/content/releases/packages/authn-simple/1-0-0.md
+++ b/content/releases/packages/authn-simple/1-0-0.md
@@ -1,0 +1,16 @@
+---
+title: Authn Simple 1.0.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/simple/).
+
+This release is for the [Authn Simple](/releases/packages/authn-simple/authn-simple/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.simple version 1.0.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.SIMPLE/1.0.0
+
+# Software
+Authn Simple software version [1.0.0](https://repo.icatproject.org/site/authn/simple/1.0.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-simple/1-0-1.md
+++ b/content/releases/packages/authn-simple/1-0-1.md
@@ -1,0 +1,16 @@
+---
+title: Authn Simple 1.0.1
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/authn/simple/).
+
+This release is for the [Authn Simple](/releases/packages/authn-simple/authn-simple/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: authn.simple version 1.0.1. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.SIMPLE/1.0.1
+
+# Software
+Authn Simple software version [1.0.1](https://repo.icatproject.org/site/authn/simple/1.0.1/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/authn-simple/authn-simple.md
+++ b/content/releases/packages/authn-simple/authn-simple.md
@@ -1,0 +1,20 @@
+---
+title: Authn Simple
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: authn.simple. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/AUTHN.SIMPLE
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/authn/simple/)
+ 
+## Previous Releases
+
+ - [1.0.1](/releases/packages/authn-simple/1-0-1/)
+ - [1.0.0](/releases/packages/authn-simple/1-0-0/)
+ 

--- a/content/releases/packages/icat-client/4-3-3.md
+++ b/content/releases/packages/icat-client/4-3-3.md
@@ -1,0 +1,16 @@
+---
+title: ICAT Client 4.3.3
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/icat/client/).
+
+This release is for the [ICAT Client](/releases/packages/icat-client/icat-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: icat.client version 4.3.3. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.CLIENT/4.3.3
+
+# Software
+ICAT Client software version [4.3.3](https://repo.icatproject.org/site/icat/client/4.3.3/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/icat-client/4-4-0.md
+++ b/content/releases/packages/icat-client/4-4-0.md
@@ -1,0 +1,15 @@
+---
+title: ICAT Client 4.4.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/icat/client/).
+
+This release is for the [ICAT Client](/releases/packages/icat-client/icat-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: icat.client version 4.4.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.CLIENT/4.4.0
+
+ICAT Client software version [4.4.0](https://repo.icatproject.org/site/icat/client/4.4.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/icat-client/4-5-0.md
+++ b/content/releases/packages/icat-client/4-5-0.md
@@ -1,0 +1,17 @@
+---
+title: ICAT Client 4.5.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/icat/client/).
+
+This release is for the [ICAT Client](/releases/packages/icat-client/icat-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: icat.client version 4.5.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.CLIENT/4.5.0
+
+# Software
+
+ICAT Client software version [4.5.0](https://repo.icatproject.org/site/icat/client/4.5.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/icat-client/icat-client.md
+++ b/content/releases/packages/icat-client/icat-client.md
@@ -1,0 +1,21 @@
+---
+title: ICAT Client
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: icat.client. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.CLIENT
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/icat/client/)
+ 
+## Previous Releases
+
+ - [4.5.0](/releases/packages/icat-client/4-5-0/)
+ - [4.4.0](/releases/packages/icat-client/4-4-0/)
+ - [4.3.3](/releases/packages/icat-client/4-3-3/)

--- a/content/releases/packages/icat-server/4-3-3.md
+++ b/content/releases/packages/icat-server/4-3-3.md
@@ -1,0 +1,17 @@
+---
+title: ICAT Server 4.3.3
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/icat/server/).
+
+This release is for the [ICAT Server](/releases/packages/icat-server/icat-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2014). The ICAT Project: icat.server version 4.3.3. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.SERVER/4.3.3
+
+# Software
+
+ICAT Server software version [4.3.3](https://repo.icatproject.org/site/icat/server/4.3.3/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/icat-server/4-4-0.md
+++ b/content/releases/packages/icat-server/4-4-0.md
@@ -1,0 +1,17 @@
+---
+title: ICAT Server 4.4.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/icat/server/).
+
+This release is for the [ICAT Server](/releases/packages/icat-server/icat-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: icat.server version 4.4.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.SERVER/4.4.0
+
+# Software
+
+ICAT Server software version [4.4.0](https://repo.icatproject.org/site/icat/server/4.4.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/icat-server/4-5-0.md
+++ b/content/releases/packages/icat-server/4-5-0.md
@@ -1,0 +1,17 @@
+---
+title: ICAT Server 4.5.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/icat/server/).
+
+This release is for the [ICAT Server](/releases/packages/icat-server/icat-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: icat.server version 4.5.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.SERVER/4.5.0
+
+# Software
+
+ICAT Server software version [4.5.0](https://repo.icatproject.org/site/icat/server/4.5.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/icat-server/icat-server.md
+++ b/content/releases/packages/icat-server/icat-server.md
@@ -1,0 +1,21 @@
+---
+title: ICAT Server
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2014). The ICAT Project: icat.server. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/ICAT.SERVER
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/icat/server/)
+ 
+## Previous Releases
+
+ - [4.5.0](/releases/packages/icat-server/4-5-0/)
+ - [4.4.0](/releases/packages/icat-server/4-4-0/)
+ - [4.3.3](/releases/packages/icat-server/4-3-3/)

--- a/content/releases/packages/ids-client/1-0-0.md
+++ b/content/releases/packages/ids-client/1-0-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Client 1.0.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/client/).
+
+This release is for the [IDS Client](/releases/packages/ids-client/ids-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.client version 1.0.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.CLIENT/1.0.0
+
+# Software
+
+IDS Client software version [1.0.0](https://repo.icatproject.org/site/ids/client/1.0.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-client/1-0-1.md
+++ b/content/releases/packages/ids-client/1-0-1.md
@@ -1,0 +1,17 @@
+---
+title: IDS Client 1.0.1
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/client/).
+
+This release is for the [IDS Client](/releases/packages/ids-client/ids-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.client version 1.0.1. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.CLIENT/1.0.1
+
+# Software
+
+IDS Client software version [1.0.1](https://repo.icatproject.org/site/ids/client/1.0.1/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-client/1-0-2.md
+++ b/content/releases/packages/ids-client/1-0-2.md
@@ -1,0 +1,17 @@
+---
+title: IDS Client 1.0.2
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/client/).
+
+This release is for the [IDS Client](/releases/packages/ids-client/ids-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.client version 1.0.2. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.CLIENT/1.0.2
+
+# Software
+
+IDS Client software version [1.0.2](https://repo.icatproject.org/site/ids/client/1.0.2/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-client/1-1-0.md
+++ b/content/releases/packages/ids-client/1-1-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Client 1.1.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/client/).
+
+This release is for the [IDS Client](/releases/packages/ids-client/ids-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.client version 1.1.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.CLIENT/1.1.0
+
+# Software
+
+IDS Client software version [1.1.0](https://repo.icatproject.org/site/ids/client/1.1.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-client/1-2-0.md
+++ b/content/releases/packages/ids-client/1-2-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Client 1.2.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/client/).
+
+This release is for the [IDS Client](/releases/packages/ids-client/ids-client/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.client version 1.2.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.CLIENT/1.2.0
+
+# Software
+
+IDS Client software version [1.2.0](https://repo.icatproject.org/site/ids/client/1.2.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-client/ids-client.md
+++ b/content/releases/packages/ids-client/ids-client.md
@@ -1,0 +1,23 @@
+---
+title: IDS Client
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: ids.client. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.CLIENT
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/ids/client/)
+ 
+## Previous Releases
+
+ - [1.2.0](/releases/packages/ids-client/1-2-0/)
+ - [1.1.0](/releases/packages/ids-client/1-1-0/)
+ - [1.0.2](/releases/packages/ids-client/1-0-2/)
+ - [1.0.1](/releases/packages/ids-client/1-0-1/)
+ - [1.0.0](/releases/packages/ids-client/1-0-0/)

--- a/content/releases/packages/ids-plugin/1-2-0.md
+++ b/content/releases/packages/ids-plugin/1-2-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Plugin 1.2.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/plugin/).
+
+This release is for the [IDS Plugin](/releases/packages/ids-plugin/ids-plugin/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2014). The ICAT Project: ids.plugin version 1.2.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.PLUGIN/1.2.0
+
+# Software
+
+IDS Plugin software version [1.2.0](https://repo.icatproject.org/site/ids/plugin/1.2.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-plugin/ids-plugin.md
+++ b/content/releases/packages/ids-plugin/ids-plugin.md
@@ -1,0 +1,19 @@
+---
+title: IDS Plugin
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2014). The ICAT Project: ids.plugin. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.PLUGIN
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/ids/plugin/)
+ 
+## Previous Releases
+
+ - [1.2.0](/releases/packages/ids-plugin/1-2-0/)

--- a/content/releases/packages/ids-server/1-0-0.md
+++ b/content/releases/packages/ids-server/1-0-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Server 1.0.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/server/).
+
+This release is for the [IDS Server](/releases/packages/ids-server/ids-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.server version 1.0.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER/1.0.0
+
+# Software
+
+IDS Server software version [1.0.0](https://repo.icatproject.org/site/ids/server/1.0.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-server/1-0-1.md
+++ b/content/releases/packages/ids-server/1-0-1.md
@@ -1,0 +1,17 @@
+---
+title: IDS Server 1.0.1
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/server/).
+
+This release is for the [IDS Server](/releases/packages/ids-server/ids-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.server version 1.0.1. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER/1.0.1
+
+# Software
+
+IDS Server software version [1.0.1](https://repo.icatproject.org/site/ids/server/1.0.1/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-server/1-1-0.md
+++ b/content/releases/packages/ids-server/1-1-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Server 1.1.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/server/).
+
+This release is for the [IDS Server](/releases/packages/ids-server/ids-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.server version 1.1.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER/1.1.0
+
+# Software
+
+IDS Server software version [1.1.0](https://repo.icatproject.org/site/ids/server/1.1.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-server/1-2-0.md
+++ b/content/releases/packages/ids-server/1-2-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Server 1.2.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/server/).
+
+This release is for the [IDS Server](/releases/packages/ids-server/ids-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.server version 1.2.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER/1.2.0
+
+# Software
+
+IDS Server software version [1.2.0](https://repo.icatproject.org/site/ids/server/1.2.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-server/1-3-0.md
+++ b/content/releases/packages/ids-server/1-3-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Server 1.3.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/server/).
+
+This release is for the [IDS Server](/releases/packages/ids-server/ids-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.server version 1.3.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER/1.3.0
+
+# Software
+
+IDS Server software version [1.3.0](https://repo.icatproject.org/site/ids/server/1.3.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-server/1-3-1.md
+++ b/content/releases/packages/ids-server/1-3-1.md
@@ -1,0 +1,17 @@
+---
+title: IDS Server 1.3.1
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/server/).
+
+This release is for the [IDS Server](/releases/packages/ids-server/ids-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.server version 1.3.1. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER/1.3.1
+
+# Software
+
+IDS Server software version [1.3.1](https://repo.icatproject.org/site/ids/server/1.3.1/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-server/1-4-0.md
+++ b/content/releases/packages/ids-server/1-4-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Server 1.4.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/server/).
+
+This release is for the [IDS Server](/releases/packages/ids-server/ids-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ids.server version 1.4.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER/1.4.0
+
+# Software
+
+IDS Server software version [1.4.0](https://repo.icatproject.org/site/ids/server/1.4.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-server/ids-server.md
+++ b/content/releases/packages/ids-server/ids-server.md
@@ -1,0 +1,25 @@
+---
+title: IDS Server
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: ids.server. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.SERVER
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/ids/server/)
+ 
+## Previous Releases
+
+ - [1.4.0](/releases/packages/ids-server/1-4-0/)
+ - [1.3.1](/releases/packages/ids-server/1-3-1/)
+ - [1.3.0](/releases/packages/ids-server/1-3-0/)
+ - [1.2.0](/releases/packages/ids-server/1-2-0/)
+ - [1.1.0](/releases/packages/ids-server/1-1-0/)
+ - [1.0.1](/releases/packages/ids-server/1-0-1/)
+ - [1.0.0](/releases/packages/ids-server/1-0-0/)

--- a/content/releases/packages/ids-storage_file/1-2-0.md
+++ b/content/releases/packages/ids-storage_file/1-2-0.md
@@ -1,0 +1,17 @@
+---
+title: IDS Storage File 1.2.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/ids/storage_file/).
+
+This release is for the [IDS Storage File](/releases/packages/ids-storage_file/ids-storage_file/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2014). The ICAT Project: ids.storage_file version 1.2.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.STORAGE_FILE/1.2.0
+
+# Software
+
+IDS Storage File software version [1.2.0](https://repo.icatproject.org/site/ids/storage_file/1.2.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ids-storage_file/ids-storage_file.md
+++ b/content/releases/packages/ids-storage_file/ids-storage_file.md
@@ -1,0 +1,19 @@
+---
+title: IDS Storage File
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2014). The ICAT Project: ids.storage_file. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IDS.STORAGE_FILE
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/ids/storage_file/)
+ 
+## Previous Releases
+
+ - [1.2.0](/releases/packages/ids-storage_file/1-2-0/)

--- a/content/releases/packages/ijp-server/2-0-1.md
+++ b/content/releases/packages/ijp-server/2-0-1.md
@@ -1,0 +1,17 @@
+---
+title: IJP Server 2.0.1
+---
+
+The full list of releases can be found via the [repository listing](https://repo.icatproject.org/site/ijp/server/).
+
+This release is for the [IJP Server](/releases/packages/ijp-server/ijp-server/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: ijp.server version 2.0.1. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IJP.SERVER/2.0.1
+
+# Software
+
+IJP Server software version [2.0.1](https://repo.icatproject.org/site/ijp/server/2.0.1/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/ijp-server/ijp-server.md
+++ b/content/releases/packages/ijp-server/ijp-server.md
@@ -1,0 +1,19 @@
+---
+title: IJP Server
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: ijp.server. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/IJP.SERVER
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/ijp/server/)
+ 
+## Previous Releases
+
+ - [2.0.1](/releases/packages/ijp-server/2-0-1/)

--- a/content/releases/packages/topcat/1-11-0.md
+++ b/content/releases/packages/topcat/1-11-0.md
@@ -1,0 +1,17 @@
+---
+title: Topcat 1.11.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/topcat/).
+
+This release is for the [Topcat](/releases/packages/topcat/topcat/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+Collaboration, T. I. C. A. T. (2015). The ICAT Project: topcat version 1.11.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/TOPCAT/1.11.0
+
+# Software
+
+Topcat software version [1.11.0](https://repo.icatproject.org/site/topcat/1.11.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/topcat/1-12-0.md
+++ b/content/releases/packages/topcat/1-12-0.md
@@ -1,0 +1,17 @@
+---
+title: Topcat 1.12.0
+---
+
+**This is NOT the latest release.** The latest release can be found via the [repository listing](https://repo.icatproject.org/site/topcat/).
+
+This release is for the [Topcat](/releases/packages/topcat/topcat/) package, which forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software release please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: topcat version 1.12.0. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/TOPCAT/1.12.0
+
+# Software
+
+Topcat software version [1.12.0](https://repo.icatproject.org/site/topcat/1.12.0/) can be accessed from the ICAT Maven site.

--- a/content/releases/packages/topcat/topcat.md
+++ b/content/releases/packages/topcat/topcat.md
@@ -1,0 +1,21 @@
+---
+title: Topcat
+---
+
+This package forms part of the [ICAT](/releases/) suit of software.
+
+# Citation
+
+When referencing this software package please use the following citation:
+
+The ICAT Collaboration. (2015). The ICAT Project: topcat. The ICAT Collaboration. https://doi.org/10.5286/SOFTWARE/ICAT/TOPCAT
+
+# Software Releases
+
+ [repository listing](https://repo.icatproject.org/site/topcat/)
+ 
+## Previous Releases
+
+ - [1.12.0](/releases/packages/topcat/1-12-0/)
+ - [1.11.0](/releases/packages/topcat/1-11-0/)
+ 


### PR DESCRIPTION
Currently there are 47 DOIs for software packages and version relating to ICAT and related components. The DOI's point to pages under http://icatproject.org/mvn/site/ a URL that no longer exists. A new set of DOI landing pages have been created under
http://icatproject.org/releases/